### PR TITLE
Changed date cast format to timestamp with milliseconds.

### DIFF
--- a/src/Checklist.php
+++ b/src/Checklist.php
@@ -33,7 +33,7 @@ class Checklist extends Model
      * @var array
      */
     protected $casts = [
-        'date_created' => 'datetime:U',
+        'date_created' => 'datetime:Uv',
         'id'           => 'string',
         'orderindex'   => 'float',
         'resolved'     => 'boolean',

--- a/src/Comment.php
+++ b/src/Comment.php
@@ -33,7 +33,7 @@ class Comment extends Model
      * @var array
      */
     protected $casts = [
-        'date'     => 'datetime:U',
+        'date'     => 'datetime:Uv',
         'id'       => 'integer',
         'resolved' => 'boolean',
     ];

--- a/src/Field.php
+++ b/src/Field.php
@@ -30,7 +30,7 @@ class Field extends Model
      * @var array
      */
     protected $casts = [
-        'date_created'    => 'datetime:U',
+        'date_created'    => 'datetime:Uv',
         'hide_from_guest' => 'boolean',
         'id'              => 'string',
     ];

--- a/src/Goal.php
+++ b/src/Goal.php
@@ -53,19 +53,19 @@ class Goal extends Model
     protected $casts = [
         'archived'          => 'boolean',
         'creator'           => 'integer',
-        'date_created'      => 'datetime:U',
-        'due_date'          => 'datetime:U',
+        'date_created'      => 'datetime:Uv',
+        'due_date'          => 'datetime:Uv',
         'folder_id'         => 'integer',
         'id'                => 'string',
         'key_result_count'  => 'integer',
-        'last_update'       => 'datetime:U',
+        'last_update'       => 'datetime:Uv',
         'multiple_owners'   => 'boolean',
         'owner'             => 'integer',
         'percent_completed' => 'float',
         'pinned'            => 'boolean',
         'pretty_id'         => 'integer',
         'private'           => 'boolean',
-        'start_date'        => 'datetime:U',
+        'start_date'        => 'datetime:Uv',
         'team_id'           => 'integer',
     ];
 

--- a/src/Interval.php
+++ b/src/Interval.php
@@ -30,10 +30,10 @@ class Interval extends Model
      * @var array
      */
     protected $casts = [
-        'date_added' => 'datetime:U',
-        'end'        => 'datetime:U',
+        'date_added' => 'datetime:Uv',
+        'end'        => 'datetime:Uv',
         'id'         => 'string',
-        'start'      => 'datetime:U',
+        'start'      => 'datetime:Uv',
         'time'       => 'integer',
     ];
 

--- a/src/Item.php
+++ b/src/Item.php
@@ -30,7 +30,7 @@ class Item extends Model
      * @var array
      */
     protected $casts = [
-        'date_created' => 'datetime:U',
+        'date_created' => 'datetime:Uv',
         'id'           => 'string',
         'orderindex'   => 'float',
         'resolved'     => 'boolean',

--- a/src/Result.php
+++ b/src/Result.php
@@ -41,7 +41,7 @@ class Result extends Model
     protected $casts = [
         'completed'         => 'boolean',
         'creator'           => 'integer',
-        'date_created'      => 'datetime:U',
+        'date_created'      => 'datetime:Uv',
         'goal_pretty_id'    => 'integer',
         'id'                => 'string',
         'percent_completed' => 'float',

--- a/src/Support/Model.php
+++ b/src/Support/Model.php
@@ -10,6 +10,8 @@ use Illuminate\Database\Eloquent\Concerns\HasAttributes;
 use Illuminate\Database\Eloquent\Concerns\HasTimestamps;
 use Illuminate\Database\Eloquent\Concerns\HidesAttributes;
 use Illuminate\Database\Eloquent\JsonEncodingException;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
 use JsonSerializable;
 use LogicException;
@@ -32,7 +34,10 @@ use Spinen\ClickUp\Support\Relations\Relation;
  */
 abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializable
 {
-    use HasAttributes, HasClient, HasTimestamps, HidesAttributes;
+    use HasAttributes {
+        asDateTime as originalAsDateTime;
+    }
+    use HasClient, HasTimestamps, HidesAttributes;
 
     /**
      * Indicates if the model exists.
@@ -114,6 +119,13 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      * @var string|null
      */
     protected $responseKey = null;
+
+    /**
+     * Are timestamps in milliseconds?
+     *
+     * @var boolean
+     */
+    protected $timestampsInMilliseconds = true;
 
     /**
      * The name of the "created at" column.
@@ -210,6 +222,21 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     public function __unset($key)
     {
         $this->offsetUnset($key);
+    }
+
+    /**
+     * Return a timestamp as DateTime object.
+     *
+     * @param  mixed  $value
+     * @return \Illuminate\Support\Carbon
+     */
+    protected function asDateTime($value)
+    {
+        if (is_numeric($value) && $this->timestampsInMilliseconds) {
+            return Date::createFromTimestampMs($value);
+        }
+
+        return $this->originalAsDateTime($value);
     }
 
     /**

--- a/src/Task.php
+++ b/src/Task.php
@@ -59,13 +59,13 @@ class Task extends Model
      */
     protected $casts = [
         'archived'      => 'boolean',
-        'date_closed'   => 'datetime:U',
-        'date_created'  => 'datetime:U',
-        'date_updated'  => 'datetime:U',
-        'due_date'      => 'datetime:U',
+        'date_closed'   => 'datetime:Uv',
+        'date_created'  => 'datetime:Uv',
+        'date_updated'  => 'datetime:Uv',
+        'due_date'      => 'datetime:Uv',
         'id'            => 'string',
         'orderindex'    => 'float',
-        'start_date'    => 'datetime:U',
+        'start_date'    => 'datetime:Uv',
         'team_id'       => 'integer',
         'time_estimate' => 'integer',
         'time_spent'    => 'integer',

--- a/src/TaskList.php
+++ b/src/TaskList.php
@@ -41,12 +41,12 @@ class TaskList extends Model
      */
     protected $casts = [
         'archived'          => 'boolean',
-        'due_date'          => 'datetime:U',
+        'due_date'          => 'datetime:Uv',
         'due_date_time'     => 'boolean',
         'id'                => 'integer',
         'orderindex'        => 'float',
         'override_statuses' => 'boolean',
-        'start_date'        => 'datetime:U',
+        'start_date'        => 'datetime:Uv',
         'start_date_time'   => 'boolean',
         'task_count'        => 'integer',
     ];

--- a/src/View.php
+++ b/src/View.php
@@ -43,7 +43,7 @@ class View extends Model
      * @var array
      */
     protected $casts = [
-        'date_created'   => 'datetime:U',
+        'date_created'   => 'datetime:Uv',
         'date_protected' => 'integer',
         'id'             => 'string',
         'orderindex'     => 'float',


### PR DESCRIPTION
API receives and returns dates in timestamps with milliseconds. It was needed to change cast format and asDateTime() method behavior.