### PR TITLE
WIP: Update Space.php - $path /space does not exist. Needs team id placeholder

### DIFF
--- a/src/Space.php
+++ b/src/Space.php
@@ -48,7 +48,7 @@ class Space extends Model
      *
      * @var string
      */
-    protected $path = '/space';
+    protected $path = '/team/{team-id}/space';
 
     /**
      * Accessor for Members.


### PR DESCRIPTION
**Problem:**
Calling

`$clickUpApi->spaces->where('team_id', '123456')`

results in

>  Client error: `GET https://api.clickup.com/api/v2/space` resulted in a `404 Not Found` response:
> {"err":"Route not found","ECODE":"APP_001"}

as the route "/space" does not exist. The API says it must be /team/_team_id_/space
`https://api.clickup.com/api/v2/team/team_id/space?archived=false`
See https://clickup.com/api

**Proposed solution:**
Change the $path and replace it by mandatory team_id.