### PR TITLE
Fix decryption to handle serialized ClickUp tokens

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^8.0.2",
         "ext-json": "*",
         "guzzlehttp/guzzle": "^7.0",
-        "laravel/framework": "^9.19|^10|^11",
+        "laravel/framework": "^9.19|^10|^11|^12",
         "nesbot/carbon": "^2.62.1|^3"
     },
     "require-dev": {

--- a/src/Concerns/HasClickUp.php
+++ b/src/Concerns/HasClickUp.php
@@ -62,7 +62,7 @@ trait HasClickUp
     public function getClickupTokenAttribute(): ?string
     {
         if (! is_null($this->attributes['clickup_token'])) {
-            return Crypt::decryptString($this->attributes['clickup_token']);
+            return unserialize(Crypt::decryptString($this->attributes['clickup_token']));
         }
 
         return null;

--- a/src/Concerns/HasClickUp.php
+++ b/src/Concerns/HasClickUp.php
@@ -7,7 +7,7 @@ use Illuminate\Contracts\Container\BindingResolutionException;
 use Illuminate\Support\Facades\Crypt;
 use Spinen\ClickUp\Api\Client as ClickUp;
 use Spinen\ClickUp\Exceptions\NoClientException;
-use Spinen\ClickUp\Support\Builder;
+use Spinen\ClickUp\Support\ClickUpBuilder;
 
 /**
  * Trait HasClickUp
@@ -20,18 +20,18 @@ trait HasClickUp
     /**
      * ClickUp Builder instance
      */
-    protected ?Builder $builder = null;
+    protected ?ClickUpBuilder $clickUpBuilder = null;
 
     /**
      * Return cached version of the ClickUp Builder for the user
      *
      * @throws BindingResolutionException
      */
-    public function clickup(): Builder
+    public function clickup(): ClickUpBuilder
     {
-        if (is_null($this->builder)) {
-            $this->builder = Container::getInstance()
-                ->make(Builder::class)
+        if (is_null($this->clickUpBuilder)) {
+            $this->clickUpBuilder = Container::getInstance()
+                ->make(ClickUpBuilder::class)
                 ->setClient(
                     Container::getInstance()
                     ->make(ClickUp::class)
@@ -39,7 +39,7 @@ trait HasClickUp
                 );
         }
 
-        return $this->builder;
+        return $this->clickUpBuilder;
     }
 
     /**
@@ -86,8 +86,8 @@ trait HasClickUp
     public function setClickupTokenAttribute(?string $clickup_token): void
     {
         // If setting the password & already have a client, then empty the client to use new password in client
-        if (! is_null($this->builder)) {
-            $this->builder = null;
+        if (! is_null($this->clickUpBuilder)) {
+            $this->clickUpBuilder = null;
         }
 
         $this->attributes['clickup_token'] = is_null($clickup_token)

--- a/src/Providers/ClientServiceProvider.php
+++ b/src/Providers/ClientServiceProvider.php
@@ -8,7 +8,7 @@ use Illuminate\Contracts\Support\DeferrableProvider;
 use Illuminate\Support\Facades\Config;
 use Illuminate\Support\ServiceProvider as LaravelServiceProvider;
 use Spinen\ClickUp\Api\Client as ClickUp;
-use Spinen\ClickUp\Support\Builder;
+use Spinen\ClickUp\Support\ClickUpBuilder;
 
 /**
  * Class ClientServiceProvider
@@ -47,7 +47,7 @@ class ClientServiceProvider extends LaravelServiceProvider implements Deferrable
     public function provides()
     {
         return [
-            Builder::class,
+            ClickUpBuilder::class,
             ClickUp::class,
         ];
     }
@@ -60,8 +60,8 @@ class ClientServiceProvider extends LaravelServiceProvider implements Deferrable
     protected function registerClient(): void
     {
         $this->app->bind(
-            Builder::class,
-            fn (Application $app): Builder => new Builder($app->make(ClickUp::class))
+            ClickUpBuilder::class,
+            fn (Application $app): ClickUpBuilder => new ClickUpBuilder($app->make(ClickUp::class))
         );
 
         $this->app->bind(

--- a/src/Support/ClickUpBuilder.php
+++ b/src/Support/ClickUpBuilder.php
@@ -17,7 +17,7 @@ use Spinen\ClickUp\Team;
 use Spinen\ClickUp\User;
 
 /**
- * Class Builder
+ * Class ClickUpBuilder
  *
  * @property Collection $spaces
  * @property Collection $tasks
@@ -30,7 +30,7 @@ use Spinen\ClickUp\User;
  * @method teams
  * @method workspaces
  */
-class Builder
+class ClickUpBuilder
 {
     use HasClient;
 

--- a/src/Support/Model.php
+++ b/src/Support/Model.php
@@ -223,10 +223,10 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     {
         $foreignKey = $foreignKey ?? $this->assumeForeignKey($related);
 
-        $builder = (new Builder())->setClass($related)
+        $clickUpBuilder = (new ClickUpBuilder())->setClass($related)
                                   ->setClient($this->getClient());
 
-        return new BelongsTo($builder, $this, $foreignKey);
+        return new BelongsTo($clickUpBuilder, $this, $foreignKey);
     }
 
     /**
@@ -243,11 +243,11 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
     {
         $foreignKey = $foreignKey ?? $this->assumeForeignKey($related);
 
-        $builder = (new Builder())->setClass($related)
+        $builder = (new ClickUpBuilder())->setClass($related)
                                   ->setClient($this->getClient())
                                   ->setParent($this);
 
-        return new ChildOf($builder, $this, $foreignKey);
+        return new ChildOf($clickUpBuilder, $this, $foreignKey);
     }
 
     /**
@@ -452,11 +452,11 @@ abstract class Model implements Arrayable, ArrayAccess, Jsonable, JsonSerializab
      */
     public function hasMany($related): HasMany
     {
-        $builder = (new Builder())->setClass($related)
+        $clickUpBuilder = (new ClickUpBuilder())->setClass($related)
                                   ->setClient($this->getClient())
                                   ->setParent($this);
 
-        return new HasMany($builder, $this);
+        return new HasMany($clickUpBuilder, $this);
     }
 
     /**

--- a/src/Support/Relations/BelongsTo.php
+++ b/src/Support/Relations/BelongsTo.php
@@ -6,7 +6,7 @@ use GuzzleHttp\Exception\GuzzleException;
 use Spinen\ClickUp\Exceptions\InvalidRelationshipException;
 use Spinen\ClickUp\Exceptions\NoClientException;
 use Spinen\ClickUp\Exceptions\TokenException;
-use Spinen\ClickUp\Support\Builder;
+use Spinen\ClickUp\Support\ClickUpBuilder;
 use Spinen\ClickUp\Support\Model;
 
 /**
@@ -21,14 +21,14 @@ class BelongsTo extends Relation
      *
      * @throws InvalidRelationshipException
      */
-    public function __construct(protected Builder $builder, protected Model $child, protected $foreignKey)
+    public function __construct(protected ClickUpBuilder $clickUpBuilder, protected Model $child, protected $foreignKey)
     {
         // In the underlying base relationship class, the "child" variable is
         // referred to as the "parentModel" since most relationships are not
         // inversed. But, since this one is we will create a "child" variable
         // for much better readability.
 
-        parent::__construct($builder->whereId($this->getForeignKey()), $this->getChild());
+        parent::__construct($clickUpBuilder->whereId($this->getForeignKey()), $this->getChild());
     }
 
     /**

--- a/src/Support/Relations/Relation.php
+++ b/src/Support/Relations/Relation.php
@@ -5,7 +5,7 @@ namespace Spinen\ClickUp\Support\Relations;
 use Illuminate\Support\Traits\ForwardsCalls;
 use Illuminate\Support\Traits\Macroable;
 use Spinen\ClickUp\Exceptions\InvalidRelationshipException;
-use Spinen\ClickUp\Support\Builder;
+use Spinen\ClickUp\Support\ClickUpBuilder;
 use Spinen\ClickUp\Support\Model;
 
 /**
@@ -30,9 +30,9 @@ abstract class Relation
      *
      * @throws InvalidRelationshipException
      */
-    public function __construct(protected Builder $builder, protected Model $parent)
+    public function __construct(protected ClickUpBuilder $clickUpBuilder, protected Model $parent)
     {
-        $this->related = $builder->getModel();
+        $this->related = $clickUpBuilder->getModel();
     }
 
     /**
@@ -56,9 +56,9 @@ abstract class Relation
     /**
      * Get the Builder instance
      */
-    public function getBuilder(): Builder
+    public function getBuilder(): ClickUpBuilder
     {
-        return $this->builder;
+        return $this->clickUpBuilder;
     }
 
     /**

--- a/tests/Concerns/HasClickUpTest.php
+++ b/tests/Concerns/HasClickUpTest.php
@@ -9,7 +9,7 @@ use Mockery\Mock;
 use ReflectionClass;
 use Spinen\ClickUp\Api\Client as ClickUp;
 use Spinen\ClickUp\Concerns\Stubs\User;
-use Spinen\ClickUp\Support\Builder;
+use Spinen\ClickUp\Support\ClickUpBuilder;
 use Spinen\ClickUp\TestCase;
 
 class HasClickUpTest extends TestCase
@@ -47,7 +47,7 @@ class HasClickUpTest extends TestCase
             )
             ->andReturnSelf();
 
-        $this->builder_mock = Mockery::mock(Builder::class);
+        $this->builder_mock = Mockery::mock(ClickUpBuilder::class);
         $this->builder_mock->shouldReceive('getClient')
             ->withNoArgs()
             ->andReturn($this->client_mock);
@@ -60,7 +60,7 @@ class HasClickUpTest extends TestCase
             ->andReturnSelf();
 
         Container::getInstance()
-            ->instance(Builder::class, $this->builder_mock);
+            ->instance(ClickUpBuilder::class, $this->builder_mock);
 
         Container::getInstance()
             ->instance(ClickUp::class, $this->client_mock);

--- a/tests/Concerns/Stubs/User.php
+++ b/tests/Concerns/Stubs/User.php
@@ -23,6 +23,6 @@ class User
 
     public function getBuilder()
     {
-        return $this->builder;
+        return $this->clickUpBuilder;
     }
 }

--- a/tests/Support/BuilderTest.php
+++ b/tests/Support/BuilderTest.php
@@ -21,9 +21,9 @@ use Spinen\ClickUp\View;
 class BuilderTest extends TestCase
 {
     /**
-     * @var Builder
+     * @var ClickUpBuilder
      */
-    protected $builder;
+    protected $clickUpBuilder;
 
     /**
      * @var Mock
@@ -50,8 +50,8 @@ class BuilderTest extends TestCase
     {
         $this->client_mock = Mockery::mock(Client::class);
 
-        $this->builder = new Builder();
-        $this->builder->setClient($this->client_mock);
+        $this->clickUpBuilder = new ClickUpBuilder();
+        $this->clickUpBuilder->setClient($this->client_mock);
     }
 
     /**

--- a/tests/Support/Relations/BelongsToTest.php
+++ b/tests/Support/Relations/BelongsToTest.php
@@ -3,7 +3,7 @@
 namespace Spinen\ClickUp\Support\Relations;
 
 use Mockery;
-use Spinen\ClickUp\Support\Builder;
+use Spinen\ClickUp\Support\ClickUpBuilder;
 use Spinen\ClickUp\Support\Collection;
 use Spinen\ClickUp\Support\Stubs\Model;
 
@@ -96,7 +96,7 @@ class BelongsToTest extends RelationCase
      */
     public function it_returns_null_if_foreign_key_is_null()
     {
-        $builder_mock = Mockery::mock(Builder::class);
+        $builder_mock = Mockery::mock(ClickUpBuilder::class);
         $builder_mock->shouldReceive('getModel')
                      ->andReturn($this->parent_mock);
         $builder_mock->shouldReceive('whereId')

--- a/tests/Support/Relations/RelationCase.php
+++ b/tests/Support/Relations/RelationCase.php
@@ -4,7 +4,7 @@ namespace Spinen\ClickUp\Support\Relations;
 
 use Mockery;
 use Mockery\Mock;
-use Spinen\ClickUp\Support\Builder;
+use Spinen\ClickUp\Support\ClickUpBuilder;
 use Spinen\ClickUp\Support\Model;
 use Spinen\ClickUp\TestCase;
 
@@ -29,7 +29,7 @@ class RelationCase extends TestCase
     {
         $this->parent_mock = Mockery::mock(Model::class);
 
-        $this->builder_mock = Mockery::mock(Builder::class);
+        $this->builder_mock = Mockery::mock(ClickUpBuilder::class);
         $this->builder_mock->shouldReceive('getModel')
                            ->andReturn($this->parent_mock);
 


### PR DESCRIPTION
Previously, the decrypted ClickUp tokens were not being unserialized, causing potential issues when accessing the stored values. This update ensures the tokens are properly unserialized after decryption to maintain functionality.